### PR TITLE
Add missing AF7 for USART3

### DIFF
--- a/Inc/stm32c0xx_hal_gpio_ex.h
+++ b/Inc/stm32c0xx_hal_gpio_ex.h
@@ -195,6 +195,7 @@ extern "C" {
   */
 #define GPIO_AF7_EVENTOUT      ((uint8_t)0x07)  /*!< EVENTOUT Alternate Function mapping */
 #define GPIO_AF7_I2C1          ((uint8_t)0x07)  /*!< I2C1 Alternate Function mapping */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /*!< USART3 Alternate Function mapping */
 /**
   * @brief   AF 8 selection
   */


### PR DESCRIPTION
According to datasheet AF7 is used for USART3_TX when on Port PC14

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32c0xx_hal_driver/blob/main/CONTRIBUTING.md) file.
